### PR TITLE
Fixing Windows backslash when computing relative paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "npm-which": "^3.0.1",
     "request": "^2.79.0",
     "request-promise": "^4.1.1",
+    "slash": "^1.0.0",
     "split-lines": "^1.0.0",
     "tough-cookie": "^2.3.2",
     "url-parse": "^1.0.5",

--- a/src/squarespace-assemble.js
+++ b/src/squarespace-assemble.js
@@ -27,7 +27,6 @@
  */
 
 const path = require('path');
-const slash = require('slash');
 const http = require('http');
 const Program = require('commander');
 const FileManager = require('./utils/FileManager');
@@ -46,7 +45,7 @@ function configServer(options) {
 
 function main(options) {
 
-  const srcDir = options.directory || slash(process.cwd());
+  const srcDir = options.directory || process.cwd();
   const buildDir = options.output || path.join(srcDir, 'build');
   const isLegacy = options.legacy || false;
   const server = configServer(options);

--- a/src/squarespace-assemble.js
+++ b/src/squarespace-assemble.js
@@ -27,6 +27,7 @@
  */
 
 const path = require('path');
+const slash = require('slash');
 const http = require('http');
 const Program = require('commander');
 const FileManager = require('./utils/FileManager');
@@ -45,7 +46,7 @@ function configServer(options) {
 
 function main(options) {
 
-  const srcDir = options.directory || process.cwd();
+  const srcDir = options.directory || slash(process.cwd());
   const buildDir = options.output || path.join(srcDir, 'build');
   const isLegacy = options.legacy || false;
   const server = configServer(options);

--- a/src/utils/FileManager.js
+++ b/src/utils/FileManager.js
@@ -25,6 +25,7 @@ const del = require('del');
 const path = require('path');
 const colors = require('colors');
 const glob = require('glob');
+const slash = require('slash');
 const { get, values } = require('lodash/object');
 const patterns = require('./patterns');
 const { merge } = require('./confutils');
@@ -183,10 +184,12 @@ class FileManager {
    * @return {string} - relative path
    */
   getRelativePath(filePath, dir) {
+    filePath = slash(filePath);
     if (dir) {
+      dir = slash(dir);
       return filePath.replace(dir, '');
     }
-    return filePath.replace(this.srcDir, '');
+    return filePath.replace(slash(this.srcDir), '');
   }
 
   /**


### PR DESCRIPTION
On Windows, `squarespace-assemble` (with no parameters) fails. Since `process.cwd()` returns a back-slashed path, and glob resolving returns forward-slashed paths, files relative paths aren't computed correctly.